### PR TITLE
docs(agents): Graphify code-memory instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,3 +384,31 @@ You have succeeded when:
 ---
 
 *For project intelligence, see `AGENT.md`*
+
+<!-- graphify-code-memory:begin -->
+## Code memory (Graphify) — use this before grepping
+
+This repo is registered for Graphify AST code-memory (tier **p1**).
+There is no dedicated HTTP MCP yet — use the report / S3 graph first.
+
+### Where to look
+
+| | |
+|---|---|
+| **In-repo** | `graphify-out/GRAPH_REPORT.md` (after CI extract commits it) |
+| **S3 graph** | `s3://ivx-graphify-graphs/graphs/Intelli-verse-X-SDK/graph.json` |
+| **S3 report** | `s3://ivx-graphify-graphs/graphs/Intelli-verse-X-SDK/GRAPH_REPORT.md` |
+| **Future MCP** | `https://graphify-intelli-verse-x-sdk.intelli-verse-x.ai/mcp` (not deployed for this tier yet) |
+
+### Agent procedure
+
+1. Read `GRAPH_REPORT.md` for communities / hotspots.
+2. Prefer structural navigation over broad greps when answering “who calls / where defined”.
+3. Fallback to normal search for fuzzy prose. Graphify is **code DNA**, not Brand DNA / vector RAG.
+
+### Ops
+
+- CI: `.github/workflows/graphify.yml` (if present) dispatches org extract
+- Org playbook: `intelli-verse-kube-infra/.agents/skills/graphify-code-memory/SKILL.md`
+- Enable MCP later via `serve_mcp: true` in `graphify/repos.yaml` (kube-infra)
+<!-- graphify-code-memory:end -->


### PR DESCRIPTION
## Summary
- Adds a clear **Code memory (Graphify)** section to `AGENTS.md` for Cursor / Claude / Codex.
- Tier **p1**: use `graphify-out/` + S3 until MCP is enabled.

## Test plan
- [ ] Agents read `AGENTS.md` and wire MCP (p0) or open `GRAPH_REPORT.md` (p1/p2)
- [ ] No secrets committed (API key retrieved from cluster only)